### PR TITLE
Fixed #19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog  
+## v5.7.1
+- Fixed - Notification not displayed when inserting an inline image (#19)
+
 ## v5.7
 
 - Added auto resize option for new messages. When enabled, each time an attachment is added / pasted inline, the extension checks if it meets the size restrictions set in the options. If so, the image is automatically resized and saved. (#12)

--- a/background.js
+++ b/background.js
@@ -43,7 +43,7 @@ browser.runtime.onMessage.addListener(async (message, sender, callback) => {
   // Image added to body of message. Return a promise to the sender.
   if (message.type == "resizeFile") {  
     //resizeFile is sent by content script when inline image is inserted. We need to tell the function that this is inline and that the action should trigger auto resize
-    return beginResize(sender.tab, message.file,false,true,true);
+    return beginResize(sender.tab, message.file,true,true,true);
   }
   // Options window requesting a file.
   if (message.type == "fetchFile") {

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "__MSG_extensionName__",
   "description": "__MSG_extensionDescription__",
-  "version": "5.7",
+  "version": "5.7.1",
   "applications": {
     "gecko": {
       "id": "shrunked@mllr.pl",


### PR DESCRIPTION
Fixed a bug in background.js, where a wrong value was being sent to beginResize, causing the notification to be hidden for inline images.