### PR TITLE
Fixed #23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog  
+
+## v5.7.2
+
+- Fixed - the image is not resized when right clicking inline image, selecting resize image and clicking ok. (#23)\
+  One of the checks (instanceof File) was failing when it should not. I have changed it to .constructor.name, which is more reliable in modern browsers, at least according to a comment on SO.
+- Fixed - the context item text is not updated (#23)\
+  After the context item text was changed when displaying an error (e.g. the image is too small), it was not reset to "Resize this image..." when displayed again for different image.
+
 ## v5.7.1
+
 - Fixed - Notification not displayed when inserting an inline image (#19)
 
 ## v5.7

--- a/api/shrunked.js
+++ b/api/shrunked.js
@@ -63,6 +63,7 @@ var shrunked = class extends ExtensionCommon.ExtensionAPI {
               if (imageIsAccepted(target.src)) {
                 if (target.width > 500 || target.height > 500) {
                   isDisabled = false;
+                  composeMenuItem.label = localeData.localizeMessage("context.single");
                 } else {
                   if (logenabled)
                     console.log("Not resizing - image is too small");
@@ -94,9 +95,9 @@ var shrunked = class extends ExtensionCommon.ExtensionAPI {
             let srcFile = new File([srcBlob], srcName);
 
             let result = await extension.emit("shrunked-compose-context", window, srcFile);
-            if (!result || !Array.isArray(result) || !(result[0] instanceof File)) {
+            if (!result || !Array.isArray(result) || (result[0].constructor.name!="File")) {
               if (logenabled)
-                console.log("Unexpected return:", result);
+                console.log("Unexpected return:", result[0]);
               return;
             }
             let [destFile] = result;

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "__MSG_extensionName__",
   "description": "__MSG_extensionDescription__",
-  "version": "5.7.1",
+  "version": "5.7.2",
   "applications": {
     "gecko": {
       "id": "shrunked@mllr.pl",


### PR DESCRIPTION
- Fixed - the image is not resized when right clicking inline image, selecting resize image and clicking ok. (#23)\
  One of the checks (instanceof File) was failing when it should not. I have changed it to .constructor.name, which is more reliable in modern browsers, at least according to a comment on SO.
- Fixed - the context item text is not updated (#23)\
  After the context item text was changed when displaying an error (e.g. the image is too small), it was not reset to "Resize this image..." when displayed again for different image.