### PR TITLE
Fixed #26

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog  
 
+## v5.8.1
+
+- Fixed error when autoresize is enabled and resize is set to "on sending mail". When sending email with these settings, autoresize would resize the images and remove them from the list of images to resize. When "when sending email" was selected, the options window tried to be created because there was no check if the autoresize option was turned on and if the options window should be ommitted. Since there was no check if the image list was empty, the code caused an exception that stopped the email sending process. (#26)
+
 ## v5.8.0
 
 - Added option to also resize images from the original e-mail when using forward / reply (#15). This feature also works with autoresize.\

--- a/background.js
+++ b/background.js
@@ -163,7 +163,7 @@ async function processAllAttachments(tab, details,isOnDemand=false) {
   if (!promises.length) {
     return result;
   }
-  if(!isOnDemand)
+  if(!isOnDemand && (options.autoResize!="attached" || options.autoResize!="all"))
     await showOptionsDialog(tab);
   await Promise.all(promises).catch(() => {
     result.cancel = true;
@@ -203,7 +203,8 @@ browser.shrunked.onNotificationCancelled.addListener(tab => cancelResize(tab.id)
 
 async function showOptionsDialog(tab) {
   let sourceFiles = tabMap.get(tab.id);
-
+  if(sourceFiles === undefined)
+    return;
   let optionsWindow = await browser.windows.create({
     url: `content/options.xhtml?tabId=${tab.id}&count=${sourceFiles.length}`,
     type: "popup",

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "__MSG_extensionName__",
   "description": "__MSG_extensionDescription__",
-  "version": "5.8.0",
+  "version": "5.8.1",
   "applications": {
     "gecko": {
       "id": "shrunked@mllr.pl",


### PR DESCRIPTION
Fixed error when autoresize is enabled and resize is set to "on sending mail". When sending email with these settings, autoresize would resize the images and remove them from the list of images to resize. When "when sending email" was selected, the options window tried to be created because there was no check if the autoresize option was turned on and if the options window should be ommitted. Since there was no check if the image list was empty, the code caused an exception that stopped the email sending process. (#26)