### PR TITLE
Fixed #40, #38, #37

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog  
+## v5.9.1
 
+- Finished ESMification process - as of TB 136 the transition period is over and old APIs no longer work. Since the extension used pre-esmification methods previously, the extension stopped working in TB 136. This is fixed (#40)
+- fixed slider value not being loaded when opening options window (#37)
+- added information that the dimensions of the image are approximate as the values shown were not exact. I do not see this as a main feature of this webextension, so I will not pursue this issue further (#38)
 ## v5.8.2
 
 - Modified imports in shrunked.js and ShrunkedImage.jsm. In TB 128 beta the lines like

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ It is used by default, to use the previous algorithm please uncheck the correspo
 - If the selected file cannot be resized, the context menu item is disabled and shows additional information instead of item being hidden.
 - Console logging can be disabled.
 
-
+## Changelog
+[CHANGELOG.md](CHANGELOG.md)
 
 ## Known issues

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -194,7 +194,7 @@
     "message": "Previous image"
   },
   "preview.resized": {
-    "message": "Resized to: $WIDTH$ px × $HEIGHT$ px",
+    "message": "Resized to (estimate): $WIDTH$ px × $HEIGHT$ px",
     "placeholders": {
       "height": {
         "content": "$2",

--- a/_locales/pl/messages.json
+++ b/_locales/pl/messages.json
@@ -194,7 +194,7 @@
     "message": "Poprzedni obraz"
   },
   "preview.resized": {
-    "message": "Nowe wymiary obrazu: $WIDTH$ px × $HEIGHT$ px",
+    "message": "Szacowane wymiary obrazu: $WIDTH$ px × $HEIGHT$ px",
     "placeholders": {
       "height": {
         "content": "$2",

--- a/api/shrunked.js
+++ b/api/shrunked.js
@@ -364,12 +364,12 @@ var shrunked = class extends ExtensionCommon.ExtensionAPI {
           });
         },
         async resizeFile(file, maxWidth, maxHeight, quality, options) {
-          const { ShrunkedImage } = ChromeUtils.import("resource://shrunked/ShrunkedImage.jsm");
+          const { ShrunkedImage } = ChromeUtils.importESModule("resource://shrunked/ShrunkedImage.sys.mjs");
 
           return new ShrunkedImage(file, maxWidth, maxHeight, quality, options).resize();
         },
         async estimateSize(file, maxWidth, maxHeight, quality) {
-          const { ShrunkedImage } = ChromeUtils.import("resource://shrunked/ShrunkedImage.jsm");
+          const { ShrunkedImage } = ChromeUtils.importESModule("resource://shrunked/ShrunkedImage.sys.mjs");
           return new ShrunkedImage(file, maxWidth, maxHeight, quality).estimateSize();
         },
       },

--- a/content/options.js
+++ b/content/options.js
@@ -55,7 +55,7 @@ addEventListener("load", async () => {
     tb_width.value = maxWidth;
     tb_height.value = maxHeight;
   }
-
+  s_quality.value=quality;
   cb_savedefault.checked = prefs["default.saveDefault"];
 
   setSize();

--- a/manifest.json
+++ b/manifest.json
@@ -2,11 +2,11 @@
   "manifest_version": 2,
   "name": "__MSG_extensionName__",
   "description": "__MSG_extensionDescription__",
-  "version": "5.8.2",
+  "version": "5.9.1",
   "applications": {
     "gecko": {
       "id": "shrunked@mllr.pl",
-      "strict_min_version": "98.0"
+      "strict_min_version": "126.0"
     }
   },
   "author": "Geoff Lankow, memeller",

--- a/modules/ExifData.sys.mjs
+++ b/modules/ExifData.sys.mjs
@@ -1,9 +1,9 @@
-var EXPORTED_SYMBOLS = ["ExifData"];
-
+const lazy = {};
 /* globals Shrunked */
-ChromeUtils.defineModuleGetter(this, "Shrunked", "resource://shrunked/Shrunked.jsm");
-
-function ExifData() { }
+ChromeUtils.defineESModuleGetters(lazy, {
+Shrunked: "resource://shrunked/Shrunked.sys.mjs",
+});
+export function ExifData() { }
 ExifData.prototype = {
   exif1: null,
   exif2: null,

--- a/modules/ShrunkedImage.sys.mjs
+++ b/modules/ShrunkedImage.sys.mjs
@@ -1,14 +1,15 @@
 /* globals ChromeWorker, fetch, File, URL */
-var EXPORTED_SYMBOLS = ["ShrunkedImage"];
-
+const lazy = {};
 /* globals ExifData, OS, Services */
-ChromeUtils.defineModuleGetter(this, "ExifData", "resource://shrunked/ExifData.jsm");
-ChromeUtils.defineModuleGetter(this, "OS", "resource://gre/modules/osfile.jsm");
-const Services = globalThis.Services || ChromeUtils.import("resource://gre/modules/Services.jsm").Services;
+ChromeUtils.defineESModuleGetters(lazy, {
+ExifData: "resource://shrunked/ExifData.sys.mjs",
+OS: "resource://gre/modules/osfile.sys.mjs",
+});
+const Services = globalThis.Services;
 
 var XHTMLNS = "http://www.w3.org/1999/xhtml";
 
-function ShrunkedImage(source, maxWidth, maxHeight, quality, options) {
+export function ShrunkedImage(source, maxWidth, maxHeight, quality, options) {
   this.maxWidth = maxWidth;
   this.maxHeight = maxHeight;
   this.imageFormat="image/jpeg";


### PR DESCRIPTION
- Finished ESMification process - as of TB 136 the transition period is over and old APIs no longer work. Since the extension used pre-esmification methods previously, the extension stopped working in TB 136. This is fixed (#40)
- fixed slider value not being loaded when opening options window (#37)
- added information that the dimensions of the image are approximate as the values shown were not exact. I do not see this as a main feature of this webextension, so I will not pursue this issue further (#38)