### PR TITLE
Remove usage of no longer available editor._contextX and editor._contextY

### DIFF
--- a/api/shrunked.js
+++ b/api/shrunked.js
@@ -279,8 +279,6 @@ var shrunked = class extends ExtensionCommon.ExtensionAPI {
 
     for (let window of Services.wm.getEnumerator("msgcompose")) {
       for (let selector of [
-        "#shrunked-content-context-separator",
-        "#shrunked-content-context-item",
         "#shrunked-attachment-context-item",
         `notification[value="shrunked-notification"]`,
       ]) {

--- a/api/shrunked.js
+++ b/api/shrunked.js
@@ -199,7 +199,7 @@ var shrunked = class extends ExtensionCommon.ExtensionAPI {
         },
         showNotification(tab, imageCount) {
           
-          return new Promise((resolve, reject) => {
+          return new Promise(async (resolve, reject) => {
             let question = localeData.localizeMessage(
               imageCount == 1 ? "question.single" : "question.plural"
             );
@@ -209,7 +209,7 @@ var shrunked = class extends ExtensionCommon.ExtensionAPI {
             let notifyBox =
               nativeTab.gComposeNotification || ((nativeTab.gNotification)?nativeTab.gNotification.notificationbox:null) || nativeTab.chromeBrowser.contentWindow.messageBrowser.contentWindow.gMessageNotificationBar.msgNotificationBar;
             let notification = notifyBox.getNotificationWithValue("shrunked-notification");
-                          if (imageCount == 0) {
+              if (imageCount == 0) {
                 if (notification) {
                   if (logenabled)
                     console.log("Removing resize notification");
@@ -248,7 +248,7 @@ var shrunked = class extends ExtensionCommon.ExtensionAPI {
                 },
               ];
 
-              notification = notifyBox.appendNotification(
+              notification = await notifyBox.appendNotification(
                 "shrunked-notification",
                 {
                   label: question,
@@ -256,6 +256,7 @@ var shrunked = class extends ExtensionCommon.ExtensionAPI {
                 },
                 buttons
               );
+              notification.dismissable = false;
               notification._promises = [{ resolve, reject }];
           });
         },

--- a/api/shrunked.json
+++ b/api/shrunked.json
@@ -151,21 +151,6 @@
         ]
       },
       {
-        "name": "onComposeContextClicked",
-        "type": "function",
-        "parameters": [
-          {
-            "name": "tab",
-            "$ref": "tabs.Tab"
-          },
-          {
-            "type": "object",
-            "isInstanceOf": "File",
-            "additionalProperties": true
-          }
-        ]
-      },
-      {
         "name": "onAttachmentContextClicked",
         "type": "function",
         "parameters": [

--- a/background.js
+++ b/background.js
@@ -109,7 +109,12 @@ browser.menus.create({
 })
 browser.menus.onClicked.addListener(async (info, tab) => {
   if (info.menuItemId == "composeContextMenuEntry") {
-    tabMap.delete(tab.id);
+    // CHECK: Should this be prevented, if there is already an open resize popup?
+
+    // Abort any pending resize promises, there could be one from the mutation
+    // observer in the content script registering the image being inserted.
+    cancelResize(tab.id);
+
     beginResize(tab, lastContextClickedFile, false, true).then(destFile => {
       if (!destFile) {
         return;

--- a/compose_script.js
+++ b/compose_script.js
@@ -184,6 +184,9 @@ async function maybeResizeInline(target) {
       let destFile = await browser.runtime.sendMessage({
         type: "resizeFile",
         file: srcFile,
+      }).catch((err) => {
+        console.error(err);
+        return;
       });
 
       if (destFile === null || destFile === undefined) {

--- a/compose_script.js
+++ b/compose_script.js
@@ -16,8 +16,63 @@ async function startup(){
       parseInlineAtStart();
   })
   
-  
-  
+  // Listener to evaluate context clicked elements.
+  document.addEventListener("contextmenu", async (e) => {
+    let composeContextMenuEntryStatus = {
+      disabled: true,
+      label: "context.single"
+    };
+    let target = document.elementFromPoint(
+      e.clientX,
+      e.clientY,
+    );
+
+    if (target?.nodeName == "IMG") {
+      if (logenabled) {
+        console.log("Context menu on an <IMG>");
+      }
+
+      if (imageIsAccepted(target)) {
+        if (target.width > 500 || target.height > 500) {
+          composeContextMenuEntryStatus.disabled = false;
+        } else {
+          if (logenabled) {
+            console.log("Not resizing - image is too small");
+          }
+          composeContextMenuEntryStatus.label = "context.tooSmall";
+        }
+      } else {
+        if (logenabled) {
+          console.log("Not resizing - image is not JPEG / PNG");
+        }
+        composeContextMenuEntryStatus.label = "context.tooSmall"
+      }
+    }
+
+    // Create an identifier on the node, so it can be found later, but clean up
+    // the DOM from any earlier actions.
+    const selectedNodes = document.querySelectorAll('[data-currently-selected-for-shrunked]');
+    selectedNodes.forEach(node => {
+      delete node.dataset.currentlySelectedForShrunked;
+    });
+    target.dataset.currentlySelectedForShrunked = true;
+    let file = composeContextMenuEntryStatus.disabled ? null : await getFileFromTarget(target)
+
+    await browser.runtime.sendMessage({
+      type: "updateComposeContextMenuEntry",
+      composeContextMenuEntryStatus,
+      file
+    })
+  })
+
+  browser.runtime.onMessage.addListener(request => {
+    switch (request.type) {
+      case "replaceTargetWithFile": {
+        let target = document.querySelector('[data-currently-selected-for-shrunked]');
+        return replaceTargetWithFile(target, request.file);
+      }
+    }
+  })
 }
 startup();
 let observer = new MutationObserver(function(mutations) {
@@ -125,43 +180,17 @@ async function maybeResizeInline(target) {
         }
       }
 
-      let srcName = "";
-      let nameParts = target.src.match(/;filename=([^,;]*)[,;]/);
-      if (nameParts) {
-        srcName = decodeURIComponent(nameParts[1]);
-      }
-
-      let response = await fetch(src);
-      let srcBlob = await response.blob();
-      let srcFile = new File([srcBlob], srcName);
-
+      let srcFile = await getFileFromTarget(target);
       let destFile = await browser.runtime.sendMessage({
         type: "resizeFile",
         file: srcFile,
-      }).catch((err) => {
-        console.error(err);
-        return;
       });
-      
+
       if (destFile === null || destFile === undefined) {
         return;
       }
-      let destURL = await new Promise(resolve => {
-        let reader = new FileReader();
-        reader.onloadend = function() {
-          let dataURL = reader.result;
-          let headerIndexEnd = dataURL.indexOf(";");
-          dataURL =
-            reader.result.substring(0, headerIndexEnd) + ";filename=" + encodeURIComponent(changeExtensionIfNeeded(destFile.name)) + dataURL.substring(headerIndexEnd);
-          resolve(dataURL);
-        };
-        reader.readAsDataURL(destFile);
-      });
       
-      target.setAttribute("src", destURL);
-      target.removeAttribute("width");
-      target.removeAttribute("height");
-      target.setAttribute("shrunked:resized", "true");
+      await replaceTargetWithFile(target, destFile);
     } catch (ex) {
       if (logenabled)
         console.error(ex);
@@ -191,4 +220,33 @@ function imageIsAccepted(image) {
   let isPNG = src.startsWith("data:image/png") || src.endsWith(".png");
   let isBMP = src.startsWith("data:image/bmp") || src.endsWith(".bmp");
   return isJPEG | isPNG | isBMP;
+}
+async function getFileFromTarget(target) {
+  let srcName = "";
+  let nameParts = target.src.match(/;filename=([^,;]*)[,;]/);
+  if (nameParts) {
+    srcName = decodeURIComponent(nameParts[1]);
+  }
+
+  let response = await fetch(target.src);
+  let srcBlob = await response.blob();
+  return new File([srcBlob], srcName);
+}
+async function replaceTargetWithFile(target, destFile) {
+  let destURL = await new Promise(resolve => {
+    let reader = new FileReader();
+    reader.onloadend = function () {
+      let dataURL = reader.result;
+      let headerIndexEnd = dataURL.indexOf(";");
+      dataURL =
+        reader.result.substring(0, headerIndexEnd) + ";filename=" + encodeURIComponent(changeExtensionIfNeeded(destFile.name)) + dataURL.substring(headerIndexEnd);
+      resolve(dataURL);
+    };
+    reader.readAsDataURL(destFile);
+  });
+
+  target.setAttribute("src", destURL);
+  target.removeAttribute("width");
+  target.removeAttribute("height");
+  target.setAttribute("shrunked:resized", "true");
 }

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
   "applications": {
     "gecko": {
       "id": "shrunked@mllr.pl",
-      "strict_min_version": "126.0"
+      "strict_min_version": "128.0"
     }
   },
   "author": "Geoff Lankow, memeller",
@@ -18,9 +18,10 @@
   },
   "default_locale": "en",
   "background": {
+    "type": "module",
     "scripts": ["background.js"]
   },
-  "permissions": ["compose", "storage", "tabs"],
+  "permissions": ["compose", "storage", "tabs", "menus"],
   "options_ui": {
     "page": "content/config.xhtml"
   },


### PR DESCRIPTION
These two properties which were used to identify the clicked on element are no longer available, and the `popupshowing` event in chrome code does not have any useful properties (they are all 0).

The missing properties cause the manual resize via the composer context menu to fail.

This is solved by moving all of this into the content script / background script.